### PR TITLE
Add gfortran compilation option

### DIFF
--- a/trajectory_analysis/mkmf_template
+++ b/trajectory_analysis/mkmf_template
@@ -1,15 +1,12 @@
 CPPFLAGS = -I/usr/local/include
-FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags)
+FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags) -O2
 
 FC = ifort # Default compiler
 LD = $(FC)
 
 ifeq ($(FC),gfortran)
-    FFLAGS += -g -O2 -fcommon
     LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs)
-    CFLAGS = -D__GFORTRAN
 else
-    FFLAGS += -fp-model strict -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    FFLAGS += -fp-model strict -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -i4 -r8 -nowarn -Wp,-w
     LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs)
-    CFLAGS = -D__IFC
 endif

--- a/trajectory_analysis/mkmf_template
+++ b/trajectory_analysis/mkmf_template
@@ -9,7 +9,7 @@ ifeq ($(FC),gfortran)
     LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs)
     CFLAGS = -D__GFORTRAN
 else
-    FFLAGS += -fp-model strict -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    FFLAGS += -fp-model strict -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
     LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs)
     CFLAGS = -D__IFC
 endif

--- a/trajectory_analysis/mkmf_template
+++ b/trajectory_analysis/mkmf_template
@@ -1,6 +1,15 @@
-CPPFLAGS = -I/usr/local/include 
-FFLAGS = $(CPPFLAGS) -fp-model strict -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
-FC = ifort
-LD = ifort
-LDFLAGS = -limf -lm -lpthread -lrt -lnetcdff -lnetcdf
-CFLAGS = -D__IFC
+CPPFLAGS = -I/usr/local/include
+FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags)
+
+FC = ifort # Default compiler
+LD = $(FC)
+
+ifeq ($(FC),gfortran)
+    FFLAGS += -g -O2 -fcommon
+    LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs)
+    CFLAGS = -D__GFORTRAN
+else
+    FFLAGS += -fp-model strict -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs)
+    CFLAGS = -D__IFC
+endif

--- a/tstorms_driver/mkmf_template
+++ b/tstorms_driver/mkmf_template
@@ -1,15 +1,12 @@
 CPPFLAGS = -I/usr/local/include
-FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags)
+FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags) -O2
 
 FC = ifort # Default compiler
 LD = $(FC)
 
 ifeq ($(FC),gfortran)
-    FFLAGS += -g -O2 -fcommon
     LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
-    CFLAGS = -D__GFORTRAN
 else
-    FFLAGS += -fltconsistency -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    FFLAGS += -fltconsistency -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -i4 -r8 -nowarn -Wp,-w
     LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
-    CFLAGS = -D__IFC
 endif

--- a/tstorms_driver/mkmf_template
+++ b/tstorms_driver/mkmf_template
@@ -1,7 +1,15 @@
-CPPFLAGS = -I/usr/local/include 
-FFLAGS = $(CPPFLAGS) -fltconsistency -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
-FC = ifort
-LD = ifort
-LDFLAGS = -limf -lm -lpthread -lrt -lnetcdff -lnetcdf -lhdf5 -lhdf5_hl
-CFLAGS = -D__IFC
+CPPFLAGS = -I/usr/local/include
+FFLAGS = $(CPPFLAGS) $(shell nf-config --fflags)
 
+FC = ifort # Default compiler
+LD = $(FC)
+
+ifeq ($(FC),gfortran)
+    FFLAGS += -g -O2 -fcommon
+    LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
+    CFLAGS = -D__GFORTRAN
+else
+    FFLAGS += -fltconsistency -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
+    CFLAGS = -D__IFC
+endif

--- a/tstorms_driver/mkmf_template
+++ b/tstorms_driver/mkmf_template
@@ -9,7 +9,7 @@ ifeq ($(FC),gfortran)
     LDFLAGS = -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
     CFLAGS = -D__GFORTRAN
 else
-    FFLAGS += -fltconsistency -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
+    FFLAGS += -fltconsistency -stack-temps -safe-cray-ptr -ftz -shared-intel -assume byterecl -g -i4 -r8 -O2 -nowarn -Wp,-w
     LDFLAGS = -limf -lm -lpthread -lrt $(shell nf-config --flibs) -lhdf5 -lhdf5_hl
     CFLAGS = -D__IFC
 endif


### PR DESCRIPTION
I have modified `mkmf_template` to enable it to be compiled with gfortran using `make FC=gfortran` (by default it still uses ifort). This will be needed to address Cambridge-ICCS/TCTrack#206 and allow TCTrack to be installed using conda.

The relevant gfortran flags were suggested by opencode/gemma-4 and I have tested that it compiles for both gfortran and ifort.

I added using `nf-config --fflags/--flibs` so netcdf is included if it wasn't already - as is the case when I use netcdf in conda. Although, this means the conda environment needs to not be activated if building TSTORMS with ifort as it will use the gfortran-compiled netcdf instead.

I also replaced the deprecated ifort flags (`-stack_temps -safe_cray_ptr -i_dynamic`) with their equivalents (`-stack-temps -safe-cray-ptr -shared-intel`).