### PR TITLE
Add compatibility with 360_day calendar

### DIFF
--- a/tstorms_driver/get_date.f90
+++ b/tstorms_driver/get_date.f90
@@ -203,6 +203,9 @@ contains
      else if (cal(1:6) == 'NOLEAP') then
                call set_calendar_type (NO_LEAP)
 
+     else if (cal(1:7) == '360_day') then
+               call set_calendar_type (THIRTY_DAY_MONTHS)
+
      else
 !              call set_calendar_type (THIRTY_DAY_MONTHS)
                call set_calendar_type (NO_LEAP)


### PR DESCRIPTION
I have added a check for "360_day" calendar and this now produces results with the correct dates. Closes #1.

Ideally it should support all of the [CF calendar names](https://cfconventions.org/cf-conventions/cf-conventions.html#calendar) but I am keeping this PR simple.